### PR TITLE
[bugfix] BEC2 Dateien wurden auf Linux mit \n Zeilenumbrüchen geschrieben

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 * Compatible with [CPython](https://www.python.org/) >= 3.10
 
 ```bash
-pip install git+https://github.com/baltech-ag/bec2format.git#v1.00.00
+pip install git+https://github.com/baltech-ag/bec2format.git#v1.00.01
 # or
-poetry add git+https://github.com/baltech-ag/bec2format.git#v1.00.00
+poetry add git+https://github.com/baltech-ag/bec2format.git#v1.00.01
 ```
 
 #### Micropython
@@ -22,7 +22,7 @@ poetry add git+https://github.com/baltech-ag/bec2format.git#v1.00.00
 
 ```python
 import mip
-mip.install("github:baltech-ag/bec2format/package.json", version="v1.00.00")
+mip.install("github:baltech-ag/bec2format/package.json", version="v1.00.01")
 ```
 
 ## How to use

--- a/bec2format/bf3file.py
+++ b/bec2format/bf3file.py
@@ -331,7 +331,7 @@ class Bf3File:
         bf3file: str | TextIO, comments: dict[str, str], rawdata: bytes
     ) -> None:
         is_file_path = isinstance(bf3file, str)
-        bf3fileobj = open(bf3file, "w") if is_file_path else bf3file
+        bf3fileobj = open(bf3file, "w", newline="\r\n") if is_file_path else bf3file
         try:
             sorted_comments = comments.items()
             if not isinstance(comments, dict):

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bec2format",
   "description": "BALTECH BEC2 file format",
-  "version": "1.00.00",
+  "version": "1.00.01",
   "authors": [
     "Baltech AG <info@baltech.de>"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bec2format"
-version = "1.00.00"
+version = "1.00.01"
 description = "BALTECH BEC2 file format"
 authors = ["Baltech AG <info@baltech.de>"]
 license = "MIT"


### PR DESCRIPTION
Wenn open() oder Path.write_text() nicht explizit das newline Argument übergeben wird, wird os.linesep benutzt. Da dieses Projekt auch auf Linux eingesetzt werden kann, wurden dort BEC2 Dateien mit \n Zeilenumbrüchen geschrieben. Um einheitlich bei \r\n zu bleiben, werden hier die Zeilenumbrüche explizit gesetzt.