### PR TITLE
max. Unterstütze Python-Version wird nicht mehr eingeschränkt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 * Compatible with [CPython](https://www.python.org/) >= 3.10
 
 ```bash
-pip install git+https://github.com/baltech-ag/bec2format.git#v1.01.00
+pip install git+https://github.com/baltech-ag/bec2format.git#v1.01.01
 # or
-poetry add git+https://github.com/baltech-ag/bec2format.git#v1.01.00
+poetry add git+https://github.com/baltech-ag/bec2format.git#v1.01.01
 ```
 
 #### Micropython
@@ -22,7 +22,7 @@ poetry add git+https://github.com/baltech-ag/bec2format.git#v1.01.00
 
 ```python
 import mip
-mip.install("github:baltech-ag/bec2format/package.json", version="v1.01.00")
+mip.install("github:baltech-ag/bec2format/package.json", version="v1.01.01")
 ```
 
 ## How to use

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bec2format",
   "description": "BALTECH BEC2 file format",
-  "version": "1.01.00",
+  "version": "1.01.01",
   "authors": [
     "Baltech AG <info@baltech.de>"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bec2format"
-version = "1.01.00"
+version = "1.01.01"
 description = "BALTECH BEC2 file format"
 authors = ["Baltech AG <info@baltech.de>"]
 license = "MIT"


### PR DESCRIPTION
Aktuell kann das Package nicht mit Python >=3.11 verwendet werden.